### PR TITLE
feat : 로그아웃 API 추가 - #20

### DIFF
--- a/src/main/java/com/finalproject/recruit/controller/MemberController.java
+++ b/src/main/java/com/finalproject/recruit/controller/MemberController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,5 +30,13 @@ public class MemberController {
     @PostMapping("/auth/login")
     public ResponseEntity<?> login(@RequestBody MemberReqDTO.Login login) {
         return memberService.login(login);
+    }
+
+    /**
+     * 로그아웃
+     */
+    @PostMapping("/auth/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken) {
+        return memberService.logout(accessToken);
     }
 }

--- a/src/main/java/com/finalproject/recruit/service/MemberService.java
+++ b/src/main/java/com/finalproject/recruit/service/MemberService.java
@@ -77,4 +77,28 @@ public class MemberService {
 
         return response.success(tokenInfo, "로그인에 성공하셨습니다.", HttpStatus.OK);
     }
+    /**
+     * 로그아웃
+     */
+    public ResponseEntity<?> logout(String accessToken) {
+
+        if (!provider.validateToken(accessToken)) {
+            return response.fail("잘못된 요청입니다.");
+        }
+
+        Authentication authentication = provider.getAuthentication(accessToken);
+
+        if (redisTemplate.opsForValue().get("RT : " + authentication.getName()) != null) {
+            redisTemplate.delete("RT : " + authentication.getName());
+        }
+
+        Long expireTime = provider.getExpiration(accessToken);
+
+        redisTemplate.opsForValue()
+                .set(accessToken, "logout", expireTime, TimeUnit.MILLISECONDS);
+
+        return response.success("로그아웃 되셨습니다.");
+
+
+    }
 }


### PR DESCRIPTION
# API 추가
- 로그아웃 API 구현

## Description
- [ ] 로그인과 동일하게 Redis를 사용한 토큰 관리

## To-Reviewer
- 추후 리팩토링 필요
- 수정사항 발생 가능
