### PR TITLE
feat : 이메일 중복체크 API 구현 - #39

### DIFF
--- a/src/main/java/com/finalproject/recruit/controller/MemberController.java
+++ b/src/main/java/com/finalproject/recruit/controller/MemberController.java
@@ -4,10 +4,7 @@ import com.finalproject.recruit.dto.member.MemberReqDTO;
 import com.finalproject.recruit.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,5 +43,13 @@ public class MemberController {
     @PostMapping("/auth/reissue")
     public ResponseEntity<?> reissue(@RequestHeader("Authorization") String accessToken) {
         return memberService.reissue(accessToken);
+    }
+
+    /**
+     * 이메일 중복 체크
+     */
+    @GetMapping("/auth/email_validation")
+    public ResponseEntity<?> validateEmail(@RequestBody MemberReqDTO.EmailValidate emailValidate) {
+        return memberService.existEmail(emailValidate.getMemberEmail());
     }
 }

--- a/src/main/java/com/finalproject/recruit/dto/member/MemberReqDTO.java
+++ b/src/main/java/com/finalproject/recruit/dto/member/MemberReqDTO.java
@@ -30,7 +30,7 @@ public class MemberReqDTO {
         private String ceoName;
 
     }
-    
+
     /**
      * 로그인 요청 DTO
      */
@@ -45,6 +45,17 @@ public class MemberReqDTO {
         public UsernamePasswordAuthenticationToken toAuthentication() {
             return new UsernamePasswordAuthenticationToken(memberEmail, password);
         }
+
+    }
+    
+    /**
+     * 이메일 중복 체크 요청 DTO
+     */
+    @Getter
+    @Setter
+    public static class EmailValidate {
+
+        private String memberEmail;
 
     }
 }

--- a/src/main/java/com/finalproject/recruit/service/MemberService.java
+++ b/src/main/java/com/finalproject/recruit/service/MemberService.java
@@ -126,4 +126,11 @@ public class MemberService {
 
         return response.success(tokenInfo, "갱신하였습니다.", HttpStatus.OK);
     }
+
+    public ResponseEntity<?> existEmail(String email) {
+        return memberRepo.existsByMemberEmail(email)?
+                response.success("가입 가능한 이메일입니다."):
+                response.fail("이미 가입된 이메일입니다.");
+
+    }
 }


### PR DESCRIPTION
# API 추가
- 이메일 중복 체크 기능 작성

## Description
- [ ] JPA Repository에서 제공하는 exists 사용하여 구현

## To-Reviewer
- 추후 리팩토링 필요
