### PR TITLE
feat: 단체 이메일 전송 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/finalproject/recruit/dto/notice/EmailReq.java
+++ b/src/main/java/com/finalproject/recruit/dto/notice/EmailReq.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
 @Builder
 public class EmailReq {
     private Long recruitId;
-    private Long applyId;
+    private List<Long> applyIds;
     private String mailContent;
     private NoticeStep noticeStep;
     private LocalDateTime interviewDate;

--- a/src/main/java/com/finalproject/recruit/parameter/EduStatus.java
+++ b/src/main/java/com/finalproject/recruit/parameter/EduStatus.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EduStatus{
 
-    재학, 졸업, 휴학
-
+    재학, 졸업, 휴학, 중퇴, 졸업예정
 
 }

--- a/src/main/java/com/finalproject/recruit/parameter/MilitaryEnum.java
+++ b/src/main/java/com/finalproject/recruit/parameter/MilitaryEnum.java
@@ -1,6 +1,7 @@
 package com.finalproject.recruit.parameter;
 
 public enum MilitaryEnum {
+    해당없음,
     면제,
     군필,
     미필

--- a/src/main/java/com/finalproject/recruit/repository/ApplyRepository.java
+++ b/src/main/java/com/finalproject/recruit/repository/ApplyRepository.java
@@ -18,4 +18,9 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     boolean existsApplyByApplyEmailAndRecruitRecruitId(String email,Long recruitId);
 
+    Optional<Apply> findByApplyEmail(String email);
+
+
+
+
 }

--- a/src/main/java/com/finalproject/recruit/service/NoticeService.java
+++ b/src/main/java/com/finalproject/recruit/service/NoticeService.java
@@ -72,7 +72,7 @@ public class NoticeService {
     @Transactional
     public ResponseEntity<?> sendEmail(EmailReq emailReq) {
         try {
-            Recruit recruit = recruitRepository.findByRecruitIdAndRecruitDeleteIsFalse(emailReq.getRecruitId()).orElseThrow(()-> new IllegalArgumentException("해당 채용공고가 존재하지 않습니다."));
+            Recruit recruit = recruitRepository.findByRecruitId(emailReq.getRecruitId()).orElseThrow(()-> new IllegalArgumentException("해당 채용공고가 존재하지 않습니다."));
             String message=emailReq.getMailContent(); //보낼 메시지
             String interviewDate = emailReq.getInterviewDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd일 HH시 mm분"));
             if (emailReq.getNoticeStep() == NoticeStep.면접제안) {
@@ -81,7 +81,6 @@ public class NoticeService {
             }
             message+="감사합니다. ";
 
-
             //이메일 전송!!
             List<String> applyEmails = emailReq.getApplyIds().stream()
                     .map(applyId -> applyRepository.findByApplyId(applyId).orElseThrow(()-> new IllegalArgumentException("해당 apply존재하지 않습니다.")))
@@ -89,7 +88,7 @@ public class NoticeService {
                     .collect(Collectors.toList());
 
             String recipient = String.join(" ",applyEmails);
-            String title = recruit.getMember().getCompanyName()+"입니다.";
+            String title = recruit.getMember().getCompanyName()+" 입니다.";
             SimpleMailMessage notice = new SimpleMailMessage();
             notice.setTo(recipient.split(" "));
             notice.setSubject(title);
@@ -120,7 +119,7 @@ public class NoticeService {
     }
 
     public ResponseEntity<?> selectStep(SelectStepReq selectStepReq) {
-        Recruit recruit = recruitRepository.findByRecruitIdAndRecruitDeleteIsFalse(selectStepReq.getRecruitId())
+        Recruit recruit = recruitRepository.findByRecruitId(selectStepReq.getRecruitId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 채용공고가 존재하지 않습니다."));
 
         String message = "안녕하세요. "+ recruit.getMember().getCompanyName()+"입니다. "+


### PR DESCRIPTION
# Title
- 이메일 전송 api(개인, 단체 모두 가능) 
- 프론트에서 요청한 enum값 추가

## Description
- [x] dependency 추가
- [x] emailReq 변경 (단체 가능하게)
- [x] NoticeService 수정
- [x] properties 파일 설정 추가

## To-Reviewer
- 관련 properties파일은 슬랙에 올리겠습니다. 
- enum값 MilitaryEnum, EduStauts 값 추가됐습니다 (프론트 요청)
