### PR TITLE
feat : 회원 가입 시 이메일 인증 API 구현 - #96

### DIFF
--- a/src/main/java/com/finalproject/recruit/controller/MemberController.java
+++ b/src/main/java/com/finalproject/recruit/controller/MemberController.java
@@ -91,4 +91,16 @@ public class MemberController {
         String memberEmail = ((AuthDTO) authentication.getPrincipal()).getMemberEmail();
         return memberService.dropMember(memberEmail);
     }
+
+    @PostMapping("/auth/number")
+    public ResponseEntity<?> sendAuthNumber(@RequestParam("memberEmail") String memberEmail) {
+        System.out.println(memberEmail);
+        return memberService.sendAuthNumber(memberEmail);
+    }
+
+    @GetMapping("/auth/number")
+    public ResponseEntity<?> authNumber(@RequestBody MemberReqDTO.AuthMail authMail) {
+        return memberService.numberAuth(authMail);
+    }
+
 }

--- a/src/main/java/com/finalproject/recruit/dto/member/MemberReqDTO.java
+++ b/src/main/java/com/finalproject/recruit/dto/member/MemberReqDTO.java
@@ -1,5 +1,6 @@
 package com.finalproject.recruit.dto.member;
 
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
@@ -84,5 +85,17 @@ public class MemberReqDTO {
 
         private String ceoName;
 
+    }
+
+    /**
+     * 회원가입 시 이메일 인증
+     */
+    @Getter
+    @Setter
+    public static class AuthMail {
+
+        private String memberEmail;
+
+        private String authNumber;
     }
 }


### PR DESCRIPTION
# Title
- 회원 가입 시 이메일 인증 API 구현

## Description
- [ ] 이메일 인증번호용 난수 생성
- [ ] 인증번호 이메일 전송 API
- [ ] Redis를 통하여 인증번호 관리
- [ ] 인증번호 인증

## To-Reviewer
- 확인 한 번 부탁드립니다~