### PR TITLE
refactor: 인재 상세페이지 서비스 - 면접일 지정 API 수정 (파라미터 변경)

### DIFF
--- a/src/main/java/com/finalproject/recruit/controller/ApplyManageController.java
+++ b/src/main/java/com/finalproject/recruit/controller/ApplyManageController.java
@@ -100,9 +100,10 @@ public class ApplyManageController {
      */
     @PutMapping("/apply/set_meeting/{applyId}")
     public ResponseEntity<?> setMeetDay(@PathVariable Long applyId,
-                                        @RequestParam(name = "meeting") String meeting) {
+                                        @RequestParam(name = "interviewDate") String interviewDate,
+                                        @RequestParam(name = "interviewTime") String interviewTime) {
 
-        return applyManageService.setMeetDay(applyId, meeting);
+        return applyManageService.setMeetDay(applyId, interviewDate, interviewTime);
     }
 
     /**

--- a/src/main/java/com/finalproject/recruit/service/ApplyManageService.java
+++ b/src/main/java/com/finalproject/recruit/service/ApplyManageService.java
@@ -267,12 +267,14 @@ public class ApplyManageService {
     /**
      * 인재 면접날짜 지정
      * @param applyId
-     * @param meeting
+     * @param interviewDate
+     * @param interviewTime
      * @return
      */
     @Transactional
-    public ResponseEntity<?> setMeetDay(Long applyId, String meeting) {
+    public ResponseEntity<?> setMeetDay(Long applyId, String interviewDate, String interviewTime) {
         try {
+            String meeting = interviewDate + "T" + interviewTime;
             LocalDateTime meetingDay = LocalDateTime.parse(meeting);
 
             Apply findApply = applyRepository.findJoinByApplyId(applyId).get();


### PR DESCRIPTION
# Title

인재 상세페이지 서비스 - 면접일 지정 API 수정 (파라미터 변경)

## Description

- 면접일 지정 API 수정 (파라미터 변경)
프론트 측의 요청으로 날짜 파라미터를 하나만 받던 것을 두개로 나눠서 받도록 변경하였습니다.
'2023-04-04T20:00:00' -> '2023-04-04', '20:00:00'
때문에 로직에 날짜와 시간 합쳐서 LocalDateTime 타입으로 변경합니다.

## To-Reviewer
큰 변경사항은 없습니다!