### PR TITLE
feat: 알림센터, 탈락인재 보관함 로그인 로직 추가 - #93

### DIFF
--- a/src/main/java/com/finalproject/recruit/config/SecurityConfig.java
+++ b/src/main/java/com/finalproject/recruit/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
     ===========================*/
     // 아래 URL은 권한검사X
     private static final String[] PUBLIC_URLS = {
-            "/userIdValidation","/test", "/drop/**", "/notice/**", "/view/**", "/auth/login", "/auth/signup"
+            "/userIdValidation","/test", "/view/**", "/auth/login", "/auth/signup"
     };
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() { //시큐리티 filter 제외, 그러나 OncePerRequestFilter는 시큐리티 필터가 아니라서 로직실행

--- a/src/main/java/com/finalproject/recruit/controller/KeepController.java
+++ b/src/main/java/com/finalproject/recruit/controller/KeepController.java
@@ -1,9 +1,11 @@
 package com.finalproject.recruit.controller;
 
+import com.finalproject.recruit.dto.member.AuthDTO;
 import com.finalproject.recruit.service.KeepService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController()
@@ -18,9 +20,9 @@ public class KeepController {
      * 최근 등록 채용폼의 탈락 인재 조회
      * */
     @GetMapping("/home")
-    public ResponseEntity<?> recentRecruit(Pageable pageable){
-        String email = "a@naver.com";
-        return keepService.recentRecruit(email, pageable);
+    public ResponseEntity<?> recentRecruit(Authentication authentication , Pageable pageable){
+        AuthDTO memberInfo = (AuthDTO) authentication.getPrincipal();
+        return keepService.recentRecruit(memberInfo.getMemberEmail(), pageable);
     }
 
     /**

--- a/src/main/java/com/finalproject/recruit/controller/NoticeController.java
+++ b/src/main/java/com/finalproject/recruit/controller/NoticeController.java
@@ -1,11 +1,13 @@
 package com.finalproject.recruit.controller;
 
+import com.finalproject.recruit.dto.member.AuthDTO;
 import com.finalproject.recruit.dto.notice.EmailReq;
 import com.finalproject.recruit.dto.notice.SelectStepReq;
 import com.finalproject.recruit.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController()
@@ -19,9 +21,9 @@ public class NoticeController {
      * 기업의 채용폼 목록 조회
      * */
     @GetMapping
-    public ResponseEntity<?> recruitList(){
-        String email = "a@naver.com";
-        return noticeService.recruitList(email);
+    public ResponseEntity<?> recruitList(Authentication authentication){
+        AuthDTO memberInfo = (AuthDTO) authentication.getPrincipal();
+        return noticeService.recruitList(memberInfo.getMemberEmail());
     }
 
     /**
@@ -34,7 +36,7 @@ public class NoticeController {
 
 
     /**
-     * 이메일 보내기 (일단 1인)
+     * 단체 이메일 보내기
      * */
     @PostMapping("/send")
     public ResponseEntity<?> sendEmail(@RequestBody EmailReq emailReq){
@@ -47,7 +49,6 @@ public class NoticeController {
      * */
     @GetMapping("/status/{recruitId}")
     public ResponseEntity<?> messageHistory(@PathVariable Long recruitId){
-        String email = "a@naver.com";
         return noticeService.messageHistory(recruitId);
     }
 

--- a/src/main/java/com/finalproject/recruit/dto/keep/ApplicantsRes.java
+++ b/src/main/java/com/finalproject/recruit/dto/keep/ApplicantsRes.java
@@ -53,7 +53,6 @@ public class ApplicantsRes {
      public static List<Keywords> doSplit(String keywordsSelect){
           if (keywordsSelect != null) {
                final String[] split = keywordsSelect.split(",");
-               Arrays.stream(split).forEach(System.out::println);
                return Arrays.stream(split)
                        .map(Keywords::valueOf)
                        .collect(Collectors.toList());


### PR DESCRIPTION
# Title
- 알림센터, 탈락인재 보관함에 auth 로직 추가

## Description
- [ ] secruityConfig 파일에서 /notice, /keep 제거
- [ ] noticeController 에 auth 추가
- [ ] keepController에 auth 추가

## To-Reviewer
controller단 간단한 로그인 로직 추가입니다.
