### PR TITLE
fix : 이메일 전송 내역 저장 로직 수정

### DIFF
--- a/src/main/java/com/finalproject/recruit/service/NoticeService.java
+++ b/src/main/java/com/finalproject/recruit/service/NoticeService.java
@@ -146,7 +146,7 @@ public class NoticeService {
             mailSend(recruit, applyEmails, message);
 
             // Sending History Archiving
-            archiveSendHistory(recruit, applyEmails, message, emailReq.getNoticeStep());
+            archiveSendHistory(recruit, emailReq.getApplyIds(), message, emailReq.getNoticeStep());
 
             return response.success("Successfully Sending Email");
 
@@ -192,9 +192,9 @@ public class NoticeService {
 
     // 이메일 전송내역 저장
     @Transactional
-    public void archiveSendHistory(Recruit recruit, List<String> applyEmails, String msg, NoticeStep step){
-        List<Apply> applies = applyEmails.stream()
-                .map(email -> applyRepository.findByApplyEmail(email).orElse(null))
+    public void archiveSendHistory(Recruit recruit, List<Long> applyIds, String msg, NoticeStep step){
+        List<Apply> applies = applyIds.stream()
+                .map(applyId -> applyRepository.findByApplyId(applyId).orElse(null))
                 .collect(Collectors.toList());
 
         // empty check


### PR DESCRIPTION
# Title
이메일 전송 api 에러 해결

## Description

- [ ] 지원서를 id로 조회하지 않고 email로 조회하여 JPA query did not return a unique result 에러 발생
- [ ] 이메일로 조회 -> applyId로 조회로 수정

## To-Reviewer
- 테스트 완료했습니다
