### PR TITLE
feat: 탈락인재 보관함 이동 / 해제 일괄 처리 기능 개발

### DIFF
--- a/src/main/java/com/finalproject/recruit/controller/ApplyManageController.java
+++ b/src/main/java/com/finalproject/recruit/controller/ApplyManageController.java
@@ -44,6 +44,15 @@ public class ApplyManageController {
     }
 
     /**
+     * 지원자 탈락인재 보관함 일괄 등록 (선택된 지원자만)
+     */
+    @PutMapping("/manage/drop")
+    public ResponseEntity<?> dropApplicants(@RequestBody ApplyIdsReq applyIdsReq) {
+
+        return applyManageService.dropApplicants(applyIdsReq);
+    }
+
+    /**
      * 지원자 합격 / 불합격 처리
      */
     @PutMapping("/manage/pass/{applyId}")
@@ -96,15 +105,6 @@ public class ApplyManageController {
     public ResponseEntity<?> dropApply(@PathVariable Long applyId) {
 
         return applyManageService.dropApply(applyId);
-    }
-
-    /**
-     * 지원자 탈락인재 보관함 일괄 등록 (선택된 지원자만)
-     */
-    @PutMapping("/apply/drop")
-    public ResponseEntity<?> dropApplicants(@RequestBody ApplyIdsReq applyIdsReq) {
-
-        return applyManageService.dropApplicants(applyIdsReq);
     }
 
     /**

--- a/src/main/java/com/finalproject/recruit/controller/ApplyManageController.java
+++ b/src/main/java/com/finalproject/recruit/controller/ApplyManageController.java
@@ -1,5 +1,6 @@
 package com.finalproject.recruit.controller;
 
+import com.finalproject.recruit.dto.applymanage.ApplyIdsReq;
 import com.finalproject.recruit.dto.applymanage.ApplyProcedureReq;
 import com.finalproject.recruit.dto.applymanage.EvaluationReq;
 import com.finalproject.recruit.dto.applymanage.MeetingDateReq;
@@ -89,12 +90,21 @@ public class ApplyManageController {
     }
 
     /**
-     * 지원자 탈락인재 보관함 이동
+     * 지원자 탈락인재 보관함 등록 / 해제
      */
     @PutMapping("/apply/drop/{applyId}")
     public ResponseEntity<?> dropApply(@PathVariable Long applyId) {
 
         return applyManageService.dropApply(applyId);
+    }
+
+    /**
+     * 지원자 탈락인재 보관함 일괄 등록 (선택된 지원자만)
+     */
+    @PutMapping("/apply/drop")
+    public ResponseEntity<?> dropApplicants(@RequestBody ApplyIdsReq applyIdsReq) {
+
+        return applyManageService.dropApplicants(applyIdsReq);
     }
 
     /**

--- a/src/main/java/com/finalproject/recruit/controller/KeepController.java
+++ b/src/main/java/com/finalproject/recruit/controller/KeepController.java
@@ -1,5 +1,6 @@
 package com.finalproject.recruit.controller;
 
+import com.finalproject.recruit.dto.applymanage.ApplyIdsReq;
 import com.finalproject.recruit.dto.member.AuthDTO;
 import com.finalproject.recruit.service.KeepService;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,15 @@ public class KeepController {
     @GetMapping("/view-applicant/eternal/{recruitId}")
     public ResponseEntity<?> eternalDeleteApplicants(@PathVariable Long recruitId, Pageable pageable){
         return keepService.eternalDeleteApplicants(recruitId, pageable);
+    }
+
+    /**
+     * 지원자 탈락인재 보관함 일괄 해제 (선택된 지원자만)
+     */
+    @PutMapping("/cancel")
+    public ResponseEntity<?> dropCancelApplicants(@RequestBody ApplyIdsReq applyIdsReq) {
+
+        return keepService.dropCancelApplicants(applyIdsReq);
     }
 
     @GetMapping("/view-applicant/search")

--- a/src/main/java/com/finalproject/recruit/dto/applymanage/ApplyIdsReq.java
+++ b/src/main/java/com/finalproject/recruit/dto/applymanage/ApplyIdsReq.java
@@ -1,0 +1,17 @@
+package com.finalproject.recruit.dto.applymanage;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplyIdsReq {
+
+    List<Long> applyIds;
+}

--- a/src/main/java/com/finalproject/recruit/exception/keep/ErrorCode.java
+++ b/src/main/java/com/finalproject/recruit/exception/keep/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     RECRUIT_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "RecruitForm not found"),
     APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "Requested Apply Not Found"),
     APPLICANTS_NOT_FOUND(HttpStatus.NOT_FOUND, "Requested Applicants Not Found"),
-    UNABLE_TO_PROCESS_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to Process Request");
+    UNABLE_TO_PROCESS_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to Process Request"),
+    FAIL_CANCEL_DROP_APPLICANTS(HttpStatus.INTERNAL_SERVER_ERROR, "Fail to Cancel Drop Applicants");
     private HttpStatus status;
     private String message;
 }

--- a/src/main/java/com/finalproject/recruit/repository/ApplyRepository.java
+++ b/src/main/java/com/finalproject/recruit/repository/ApplyRepository.java
@@ -52,4 +52,12 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
     @Modifying
     @Query("update Apply a set a.applyProcedure = :applyProcedure where a.applyId IN (:applyIds)")
     void updateApplicantProcedure(@Param("applyProcedure") ApplyProcedure applyProcedure, @Param("applyIds") List<Long> applyIds);
+
+    @Modifying
+    @Query("update Apply a set a.failApply = true where a.applyId IN (:applyIds)")
+    void updateApplicantsDrop(@Param("applyIds") List<Long> applyIds);
+
+    @Modifying
+    @Query("update Apply a set a.failApply = false where a.applyId IN (:applyIds)")
+    void updateApplicantsDropCancel(@Param("applyIds") List<Long> applyIds);
 }

--- a/src/main/java/com/finalproject/recruit/service/ApplyManageService.java
+++ b/src/main/java/com/finalproject/recruit/service/ApplyManageService.java
@@ -377,6 +377,28 @@ public class ApplyManageService {
     }
 
     /**
+     * 탈락인재 보관함 이동 (일괄처리)
+     * @param applyIdsReq
+     * @return
+     */
+    @Transactional
+    public ResponseEntity<?> dropApplicants(ApplyIdsReq applyIdsReq) {
+        try {
+
+            applyRepository.updateApplicantsDrop(applyIdsReq.getApplyIds());
+
+        } catch (ApplyManageException e) {
+            return response.fail(
+                    ErrorCode.FAIL_DROP_APPLICANT.getMessage(),
+                    ErrorCode.FAIL_DROP_APPLICANT.getStatus()
+            );
+        }
+
+        return response.success("Success to Move Applicants in DropBox!");
+    }
+
+
+    /**
      * 인재 면접날짜 지정
      * @param applyId
      * @param meetingDateReq

--- a/src/main/java/com/finalproject/recruit/service/KeepService.java
+++ b/src/main/java/com/finalproject/recruit/service/KeepService.java
@@ -1,6 +1,7 @@
 package com.finalproject.recruit.service;
 
 import com.finalproject.recruit.dto.Response;
+import com.finalproject.recruit.dto.applymanage.ApplyIdsReq;
 import com.finalproject.recruit.dto.keep.ApplicantsRes;
 import com.finalproject.recruit.entity.Apply;
 import com.finalproject.recruit.entity.Mail;
@@ -141,5 +142,25 @@ public class KeepService {
                 applicantsResList,
                 "Successfully Get Deleted Applicants List"
         );
+    }
+
+    /*===========================
+        탈락인재 보관 해제 일괄처리
+        (선택된 지원자만)
+    ===========================*/
+    @Transactional
+    public ResponseEntity<?> dropCancelApplicants(ApplyIdsReq applyIdsReq) {
+        try {
+
+            applyRepository.updateApplicantsDropCancel(applyIdsReq.getApplyIds());
+
+        } catch (KeepException e) {
+            return response.fail(
+                    ErrorCode.FAIL_CANCEL_DROP_APPLICANTS.getMessage(),
+                    ErrorCode.FAIL_CANCEL_DROP_APPLICANTS.getStatus()
+            );
+        }
+
+        return response.success("Success to Cancel Applicants in DropBox!");
     }
 }


### PR DESCRIPTION
# Title

탈락인재 보관함 이동 / 해제 일괄 처리 기능 개발

## Description
- 기존 하나의 지원자에 대해서만 탈락인재 보관함 이동이 가능하였으나 이를 개선하기 위하여 개발
- IN절을 사용한 업데이트 쿼리로 처리
- 선택한 지원자를 탈락인재 보관함으로 모두 이동
- 선택한 지원자를 탈락인재 보관함에서 모두 해제

## To-Reviewer

코드리뷰 부탁드리겠습니다 !