### PR TITLE
feat: 가장 최근 사용한 채용폼 상세조회 (Redis 이용 - 성능개선 목적)

### DIFF
--- a/src/main/java/com/finalproject/recruit/config/RedisConfig.java
+++ b/src/main/java/com/finalproject/recruit/config/RedisConfig.java
@@ -1,5 +1,9 @@
 package com.finalproject.recruit.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +13,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -44,8 +49,16 @@ public class RedisConfig {
         RedisTemplate<Object, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory());
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
         return template;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() { //DTO 저장하기 위해 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+        objectMapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+        return objectMapper;
     }
 
 }

--- a/src/main/java/com/finalproject/recruit/controller/RecruitController.java
+++ b/src/main/java/com/finalproject/recruit/controller/RecruitController.java
@@ -44,8 +44,18 @@ public class RecruitController {
         채용폼 상세조회
     ===========================*/
     @GetMapping("/{recruit_id}")
-    public ResponseEntity<?> detailRecruit(@PathVariable Long recruit_id){
-        return recruitService.selectRecruitDetail(recruit_id);
+    public ResponseEntity<?> detailRecruit(@PathVariable Long recruit_id,
+                                           Authentication authentication){
+        AuthDTO memberInfo = (AuthDTO) authentication.getPrincipal();
+        return recruitService.selectRecruitDetail(memberInfo.getMemberEmail(), recruit_id);
+    }
+
+    /*===========================
+        채용폼 상세조회 Redis
+    ===========================*/
+    @GetMapping("/recent/{memberEmail}")
+    public ResponseEntity<?> findRecentRecruit(@PathVariable String memberEmail){
+        return recruitService.findRecentRecruit(memberEmail);
     }
 
 

--- a/src/main/java/com/finalproject/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/finalproject/recruit/repository/RecruitRepository.java
@@ -18,5 +18,6 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
         탈락인재 & 알람 & 지원자
     ===========================*/
     Optional<Recruit> findTopByAndMemberMemberEmailOrderByRecruitRegistedAt(String email);
+    Optional<Recruit> findTopByMember_MemberEmailOrderByRecruitRegistedAt(String memberEmail);
     List<Recruit> findByMemberMemberEmail(String memberEmail);
 }


### PR DESCRIPTION
# Title

자주 호출되는 API 성능 개선 목적을 위해 가장 최근 사용한 채용폼 상세조회를 Redis를 이용해 구현

## Description

- 채용폼 상세조회 최신폼으로 가져오기 레디스로 구현하여 성능개선
- ObjectMapper 설정을 통해RecruitRes DTO 저장,조회 가능하도록 수정
- 채용폼 상세조회, 신규등록, 수정 시 -> Redis에 채용폼 저장
- 채용폼 저장 시 key 값은 "recentRecruit::"+ memberEmail 로 저장
- value는 RecruitRes
- 채용폼 삭제 시 -> Redis에 저장된 것 그냥 삭제처리
- 만약 Redis에 저장된 채용폼이 없을 경우 가장 최근 등록된 채용폼 불러오도록 구현

## To-Reviewer

코드리뷰 상세히 부탁드릴게욧 ! 문제있는 부분 있을 수 있습니다 ㅜㅜ
LocalDateTime이 들어가있는 DTO 저장과 조회를 위해서 ObjecMapper를 만들고 RedisConfig 설정을 변경하였습니다!
레디스를 사용하는 로그인 로그아웃에는 문제는 없었습니다 !