### PR TITLE
refactor : redis 캐시 적용한 채용폼 조회, 수정 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/finalproject/recruit/config/CacheConfig.java
+++ b/src/main/java/com/finalproject/recruit/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package com.finalproject.recruit.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager RedisCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())) // Value Serializer 변경
+                .entryTtl(Duration.ofMinutes(3L)); // 캐시 수명 30분
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+
+
+}

--- a/src/main/java/com/finalproject/recruit/controller/RecruitController.java
+++ b/src/main/java/com/finalproject/recruit/controller/RecruitController.java
@@ -1,7 +1,9 @@
 package com.finalproject.recruit.controller;
 
+import com.finalproject.recruit.dto.Response;
 import com.finalproject.recruit.dto.member.AuthDTO;
 import com.finalproject.recruit.dto.recruit.RecruitReq;
+import com.finalproject.recruit.dto.recruit.RecruitRes;
 import com.finalproject.recruit.service.RecruitService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class RecruitController {
     private final RecruitService recruitService;
+
+    private final Response response;
 
     /*===========================
         채용폼 목록조회
@@ -51,6 +55,17 @@ public class RecruitController {
     }
 
     /*===========================
+      채용폼 상세조회 캐싱 추가
+  ===========================*/
+    @GetMapping("/cache/{recruit_id}")
+    public ResponseEntity<?> detailRecruitCache(@PathVariable Long recruit_id,
+                                           Authentication authentication){
+        AuthDTO memberInfo = (AuthDTO) authentication.getPrincipal();
+        RecruitRes recruitRes = recruitService.selectRecruitDetailCache(memberInfo.getMemberEmail(), recruit_id);
+        return response.success(recruitRes);
+    }
+
+    /*===========================
         채용폼 상세조회 Redis
     ===========================*/
     @GetMapping("/recent/{memberEmail}")
@@ -65,6 +80,15 @@ public class RecruitController {
     @PutMapping("/{recruit_id}")
     public ResponseEntity<?> editRecruit(@RequestBody RecruitReq req, @PathVariable Long recruit_id){
         return recruitService.editRecruit(req, recruit_id);
+    }
+
+    /*===========================
+      채용폼 수정 : 캐싱 사용
+  ===========================*/
+    @PutMapping("/cache/{recruit_id}")
+    public ResponseEntity<?> editRecruitCache(@RequestBody RecruitReq req, @PathVariable Long recruit_id){
+        RecruitRes recruitRes = recruitService.editRecruitCache(req, recruit_id);
+        return response.success(recruitRes);
     }
 
     /*===========================

--- a/src/main/java/com/finalproject/recruit/dto/recruit/RecruitRes.java
+++ b/src/main/java/com/finalproject/recruit/dto/recruit/RecruitRes.java
@@ -1,12 +1,13 @@
 package com.finalproject.recruit.dto.recruit;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.finalproject.recruit.entity.Recruit;
-import com.finalproject.recruit.repository.RecruitRepository;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter @Setter
 @NoArgsConstructor
@@ -29,12 +30,33 @@ public class RecruitRes {
     private boolean ongoing;
     private String procedure;
     //-------------------------------
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime docsStart;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime docsEnd;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime meetStart;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime meetEnd;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime confirmStart;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime confirmEnd;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime updateAt;
 
     /*===========================


### PR DESCRIPTION
# Title
- 채용폼 조회, 수정 api에 cache 적용한 api를 추가함

## Description
- [ ] 채용폼은 조회는 많이 되지만 수정은 거의 일어나지 않으므로 캐시에 넣기에 적합하다고 판단
- [ ] gradle 파일에 redis-cache관련 추가
- [ ] cacheConfig 추가
- [ ] 채용폼 조회 api에 cacheable 추가
- [ ] 채용폼 수정 api에 cacheput 추가
- [ ] 채용폼 res dto 수정 - localdatetime 에러 해결 위해 serialize 어노테이션 붙여줌

## To-Reviewer
- 확인 부탁드립니다!
